### PR TITLE
feat: 이용자 가입 API를 /user/signup으로 변경

### DIFF
--- a/src/sections/user/components/user-add-modal.tsx
+++ b/src/sections/user/components/user-add-modal.tsx
@@ -20,7 +20,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { Iconify } from '@/components/iconify';
 import type { CreateUserRequest } from '@/types/api';
-import { groupService, type UserGroup } from '@/services/groupService';
+import { useAuth } from '@/contexts/AuthContext';
 
 // ----------------------------------------------------------------------
 
@@ -30,48 +30,27 @@ type UserAddModalProps = {
   onSave: (userData: CreateUserRequest) => Promise<void>;
 };
 
-// 그룹 옵션은 서버에서 조회합니다.
-
-type FormState = CreateUserRequest & { code: string };
+type FormState = Omit<CreateUserRequest, 'institutionId'> & {
+  passwordConfirm: string;
+};
 
 const createInitialFormState = (): FormState => ({
+  username: '',
+  password: '',
+  passwordConfirm: '',
   name: '',
-  code: '',
   phone: '',
   birthDate: '',
-  // guardianName: '',
-  // guardianRelation: '',
-  // guardianPhone: '',
-  groupIds: [],
 });
 
 export function UserAddModal({ open, onClose, onSave }: UserAddModalProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const { user } = useAuth();
 
   const [formData, setFormData] = useState<FormState>(() => createInitialFormState());
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [groups, setGroups] = useState<UserGroup[]>([]);
-  const [isLoadingGroups, setIsLoadingGroups] = useState(false);
-
-  useEffect(() => {
-    if (!open) return; // 닫혀있을 땐 호출 안 함
-    const fetchGroups = async () => {
-      try {
-        setIsLoadingGroups(true);
-        const list = await groupService.getGroups();
-        setGroups(list);
-        // 기본값이 없으면 첫 번째 그룹으로 설정
-        setFormData((prev) => ({ ...prev, groupIds: prev.groupIds && prev.groupIds.length ? prev.groupIds : (list[0]?.id ? [list[0].id] : []) }));
-      } catch (e) {
-        console.error('그룹 목록을 불러오지 못했습니다.', e);
-      } finally {
-        setIsLoadingGroups(false);
-      }
-    };
-    fetchGroups();
-  }, [open]);
 
   const handleInputChange = (field: keyof FormState) => (
     event: ChangeEvent<HTMLInputElement>
@@ -97,27 +76,45 @@ export function UserAddModal({ open, onClose, onSave }: UserAddModalProps) {
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
 
-    if (!formData.name.trim() || !formData.code.trim()) {
-      setError('이름과 이용자 코드는 필수 항목입니다.');
+    // Validation
+    if (!formData.name.trim()) {
+      setError('이름은 필수 항목입니다.');
       return;
     }
-    if (!formData.groupIds || formData.groupIds.length === 0) {
-      setError('케어 그룹을 선택하세요.');
+    if (!formData.username.trim()) {
+      setError('사용자 아이디는 필수 항목입니다.');
+      return;
+    }
+    if (formData.username.trim().length < 3 || formData.username.trim().length > 100) {
+      setError('사용자 아이디는 3~100자 사이여야 합니다.');
+      return;
+    }
+    if (!formData.password.trim()) {
+      setError('비밀번호는 필수 항목입니다.');
+      return;
+    }
+    if (formData.password.trim().length < 4 || formData.password.trim().length > 50) {
+      setError('비밀번호는 4~50자 사이여야 합니다.');
+      return;
+    }
+    if (formData.password !== formData.passwordConfirm) {
+      setError('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (!user?.institutionId) {
+      setError('복지관 정보를 찾을 수 없습니다.');
       return;
     }
 
     const payload: CreateUserRequest = {
-      // ...formData,
+      institutionId: user.institutionId,
+      username: formData.username.trim(),
+      password: formData.password.trim(),
       name: formData.name.trim(),
-      loginCode: formData.code.trim(),
-      phone: formData.phone.trim(),
-      birthDate: formData.birthDate.trim(),
-      // guardianName: formData.guardianName.trim(),
-      // guardianRelation: formData.guardianRelation.trim(),
-      // guardianPhone: formData.guardianPhone.trim(),
-      groupIds: formData.groupIds,
+      phone: formData.phone.trim() || undefined,
+      birthDate: formData.birthDate.trim() || undefined,
     };
-    console.log(payload);
+
     try {
       setIsSubmitting(true);
       setError(null);
@@ -216,11 +213,12 @@ export function UserAddModal({ open, onClose, onSave }: UserAddModalProps) {
 
               <TextField
                 fullWidth
-                label="이용자 코드 *"
-                value={formData.code}
-                onChange={handleInputChange('code')}
-                placeholder="예: A001"
+                label="사용자 아이디 *"
+                value={formData.username}
+                onChange={handleInputChange('username')}
+                placeholder="3~100자 (예: user001)"
                 disabled={isSubmitting}
+                helperText="로그인에 사용될 아이디입니다 (3~100자)"
                 sx={{
                   '& .MuiOutlinedInput-root': {
                     bgcolor: 'grey.100',
@@ -231,11 +229,28 @@ export function UserAddModal({ open, onClose, onSave }: UserAddModalProps) {
 
               <TextField
                 fullWidth
-                label="생년월일"
-                type="date"
-                value={formData.birthDate}
-                onChange={handleInputChange('birthDate')}
-                InputLabelProps={{ shrink: true }}
+                type="password"
+                label="비밀번호 *"
+                value={formData.password}
+                onChange={handleInputChange('password')}
+                placeholder="4~50자"
+                disabled={isSubmitting}
+                helperText="4~50자"
+                sx={{
+                  '& .MuiOutlinedInput-root': {
+                    bgcolor: 'grey.100',
+                    borderRadius: 2,
+                  },
+                }}
+              />
+
+              <TextField
+                fullWidth
+                type="password"
+                label="비밀번호 확인 *"
+                value={formData.passwordConfirm}
+                onChange={handleInputChange('passwordConfirm')}
+                placeholder="비밀번호를 다시 입력하세요"
                 disabled={isSubmitting}
                 sx={{
                   '& .MuiOutlinedInput-root': {
@@ -261,45 +276,20 @@ export function UserAddModal({ open, onClose, onSave }: UserAddModalProps) {
               />
 
               <TextField
-                select
                 fullWidth
-                label="케어 그룹"
-                SelectProps={{
-                  multiple: true,
-                  renderValue: (selected) =>
-                    Array.isArray(selected)
-                      ? (selected as number[])
-                          .map((id) => groups.find((g) => g.id === id)?.name || id)
-                          .join(', ')
-                      : '',
-                }}
-                value={formData.groupIds}
-                onChange={(e) => {
-                  const value = e.target.value as unknown as number[];
-                  setFormData((prev) => ({ ...prev, groupIds: Array.isArray(value) ? value : [value as unknown as number] }));
-                }}
-                disabled={isSubmitting || isLoadingGroups || groups.length === 0}
-                helperText={
-                  isLoadingGroups
-                    ? '그룹 목록을 불러오는 중...'
-                    : groups.length === 0
-                    ? '그룹이 없습니다. 상단 툴바에서 그룹을 먼저 추가하세요.'
-                    : '여러 개 선택 가능'
-                }
+                label="생년월일"
+                type="date"
+                value={formData.birthDate}
+                onChange={handleInputChange('birthDate')}
+                InputLabelProps={{ shrink: true }}
+                disabled={isSubmitting}
                 sx={{
                   '& .MuiOutlinedInput-root': {
                     bgcolor: 'grey.100',
                     borderRadius: 2,
                   },
                 }}
-              >
-                {groups.map((g) => (
-                  <MenuItem key={g.id} value={g.id}>
-                    <Checkbox checked={formData.groupIds.includes(g.id)} />
-                    <ListItemText primary={g.name} />
-                  </MenuItem>
-                ))}
-              </TextField>
+              />
             </Box>
           </Box>
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -27,14 +27,22 @@ export interface User {
 }
 
 export interface CreateUserRequest {
-  loginCode?: string;
+  institutionId: number;
+  username: string;
+  password: string;
   name: string;
-  phone: string;
-  birthDate: string;
-  // guardianName: string;
-  // guardianRelation: string;
-  // guardianPhone: string;
-  groupIds: number[];
+  phone?: string;
+  birthDate?: string;
+}
+
+export interface CreateUserResponse {
+  userId: number;
+  username: string;
+  name: string;
+  institutionId: number;
+  institutionName: string;
+  createdAt: string;
+  message: string;
 }
 
 export interface UpdateUserRequest extends Partial<CreateUserRequest> {


### PR DESCRIPTION
- API 엔드포인트 변경: POST /user/register → POST /user/signup
- CreateUserRequest 타입 업데이트
  - institutionId, username, password 필드 추가 (필수)
  - phone, birthDate를 선택 필드로 변경
  - groupIds 필드 제거
- ApiClient에 skipAuth 옵션 추가
  - public endpoint 호출 시 인증 헤더 제외
  - 403 에러 핸들링에서 skipAuth 옵션 고려
- 사용자 추가 모달 UI 개선
  - 사용자 아이디(username) 입력 필드 추가
  - 비밀번호 및 비밀번호 확인 필드 추가
  - 케어 그룹 선택 제거
  - institutionId는 로그인한 관리자 정보에서 자동 설정
  - 필드 유효성 검증 강화 (3-100자, 4-50자 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 생성 시 비밀번호 기반 인증 추가

* **개선사항**
  * 사용자 아이디 필드 추가 및 입력 방식 개선
  * 비밀번호 및 비밀번호 확인 필드 추가
  * 그룹 선택 UI 제거
  * 검증 규칙 업데이트(사용자명, 비밀번호 길이 제한 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->